### PR TITLE
Add start of CI workflow, fix linting errors

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,32 @@
+name: Run CI Checks
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  lint:
+    name: Run linting checks
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+
+      - name: Run go vet
+        run: make vet
+
+      - name: Run linting
+        run: make lint
+      
+      - name: Run tests
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,11 @@ lint: golangci-lint ## Run golangci-lint linter.
 lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes.
 	cd reference-api && $(GOLANGCI_LINT) run --fix
 
+##@ Test
+.PHONY: test
+test: ## Run go tests
+	cd reference-api && go test .
+
 
 ##@ Build
 

--- a/reference-api/sources/github/commits.go
+++ b/reference-api/sources/github/commits.go
@@ -2,7 +2,6 @@ package github
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
@@ -73,25 +72,22 @@ func CommitsHandler(w http.ResponseWriter, r *http.Request) {
 	repo := r.URL.Query().Get("repo")
 	gitRef := r.URL.Query().Get("gitRef") // Get the gitRef parameter
 	if repo == "" {
-		w.WriteHeader(http.StatusBadRequest)
-		json.NewEncoder(w).Encode(ErrorResponse{Error: "Missing 'repo' query parameter"})
+		errorEncoder(w, http.StatusBadRequest, "Missing 'repo' query parameter")
 		return
 	}
 	if gitRef == "" {
-		w.WriteHeader(http.StatusBadRequest)
-		json.NewEncoder(w).Encode(ErrorResponse{Error: "Missing 'gitRef' query parameter"})
+		errorEncoder(w, http.StatusBadRequest, "Missing 'gitRef' query parameter")
 		return
 	}
 
 	// Fetch the commits
 	commits, err := FetchCommits(repo, gitRef)
 	if err != nil {
-		w.WriteHeader(http.StatusNotFound)
-		json.NewEncoder(w).Encode(ErrorResponse{Error: err.Error()})
+		errorEncoder(w, http.StatusNotFound, err.Error())
 		return
 	}
 
 	// Respond with the merged commits
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(commits)
+	responseEncoder(w, http.StatusOK, commits)
 }

--- a/reference-api/unified_handler.go
+++ b/reference-api/unified_handler.go
@@ -29,14 +29,22 @@ func (deps *HandlerDeps) UnifiedHandler(w http.ResponseWriter, r *http.Request) 
 
 	if repo == "" || gitRef == "" {
 		w.WriteHeader(http.StatusBadRequest)
-		fmt.Fprintln(w, "Missing 'repo' or 'gitRef' query parameter")
+		_, err := fmt.Fprintln(w, "Missing 'repo' or 'gitRef' query parameter")
+		if err != nil {
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		}
 		return
 	}
 
 	// Return an error if gitRef is "latest"
 	if gitRef == "latest" {
 		w.WriteHeader(http.StatusBadRequest)
-		fmt.Fprintln(w, "'latest' is not a valid value for 'gitRef' please use an immutable image that matches a gitRef on your application repository")
+		errMsg := "'latest' is not a valid value for 'gitRef' please use an immutable image that matches a gitRef on" +
+			" your application repository"
+		_, err := fmt.Fprintln(w, errMsg)
+		if err != nil {
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		}
 		return
 	}
 


### PR DESCRIPTION
This PR:
- adds a `test` target to the Makefile
- runs `go vet`, `go test`, and linting in a CI workflow
- Fixes errors that the linter uncovered

Eventually we may want to switch to Golang CI's [dedicated Github Action](https://golangci-lint.run/welcome/install/#github-actions)