### PR TITLE
Update manifeset labels & using goreleaser tag instead of sha

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # pin@v4
+        uses: actions/setup-go@v4
         with:
           go-version: 1.22
 

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes.
 build: build-ui build-go ## Build the UI extension and the reference-api binary
 
 .PHONY: build-go
-build-go: fmt vet ## Build the ephemeral-access binary.
+build-go: fmt vet ## Build the reference-api binary.
 	cd reference-api && go build -o bin/reference-api .
 
 .PHONY: clean-ui

--- a/config/reference-api/manifest.yaml
+++ b/config/reference-api/manifest.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/component: reference-api
     app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/name: argocd-ephemeral-access
+    app.kubernetes.io/name: argocd-release-details
   name: reference-api
 ---
 apiVersion: v1

--- a/config/reference-api/service_account.yaml
+++ b/config/reference-api/service_account.yaml
@@ -3,6 +3,6 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/component: reference-api
-    app.kubernetes.io/name: argocd-ephemeral-access
+    app.kubernetes.io/name: argocd-release-details
     app.kubernetes.io/managed-by: kustomize
   name: reference-api


### PR DESCRIPTION
**CHANGES**
* Updating goreleaser pin, still using v4 but using the tag instead of the sha 
* Removed manifest references to the ephemeral access plugin used as a model for this plugin