### PR TITLE
fix: added gcp-auth id for use in login-action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,6 +35,7 @@ jobs:
           go-version: 1.22
 
       - name: Google authentication
+        id: gcp-auth
         uses: google-github-actions/auth@v2
         with:
           token_format: "access_token"


### PR DESCRIPTION
CHANGES: 
* Outputs with this ID are used in the docker login-action