### PR TITLE
feat(reference-api): using golang-lru to cache github responses, updated unified handler, main and tests

### DIFF
--- a/reference-api/go.mod
+++ b/reference-api/go.mod
@@ -11,6 +11,7 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
+	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/reference-api/go.mod
+++ b/reference-api/go.mod
@@ -5,13 +5,13 @@ go 1.22.3
 require (
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/google/go-github/v67 v67.0.1-0.20241202213040-cea0bba46cd1
+	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/stretchr/testify v1.10.0
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
-	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/reference-api/go.sum
+++ b/reference-api/go.sum
@@ -9,6 +9,8 @@ github.com/google/go-github/v67 v67.0.1-0.20241202213040-cea0bba46cd1 h1:pAaAxMa
 github.com/google/go-github/v67 v67.0.1-0.20241202213040-cea0bba46cd1/go.mod h1:zH3K7BxjFndr9QSeFibx4lTKkYS3K9nDanoI1NjaOtY=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
+github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
+github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=

--- a/reference-api/main.go
+++ b/reference-api/main.go
@@ -5,20 +5,49 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strconv"
 
+	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/mozilla/argocd-repository-details/reference-api/sources/github"
 )
 
+func onEvict(key string, value []byte) {
+	// Function called during eviction, log key evicted from cache
+	log.Printf("Evicted from cache: %s", key)
+}
+
 func main() {
-	deps := &HandlerDeps{CommitsHandler: github.CommitsHandler, ReleasesHandler: github.ReleasesHandler}
+	// Create an LRU cache with eviction callback, cacheSize configurable by environment variable (CacheSize)
+	cacheSize := 1000
+	if cs := os.Getenv("CacheSize"); cs != "" {
+		if parsedSize, err := strconv.Atoi(cs); err == nil {
+			cacheSize = parsedSize
+		} else {
+			log.Printf("Invalid CacheSize value: %s, using default: %d", cs, cacheSize)
+		}
+	}
+
+	cache, err := lru.NewWithEvict[string, []byte](cacheSize, onEvict)
+	if err != nil {
+		log.Fatalf("Failed to create cache: %v", err)
+	}
+
+	// Initialize dependencies with cache
+	deps := &HandlerDeps{
+		CommitsHandler:  github.CommitsHandler,
+		ReleasesHandler: github.ReleasesHandler,
+		cache:           cache,
+	}
 
 	// Unified handler for both releases and commits, may support additional sources in the future.
 	http.HandleFunc("/api/references", deps.UnifiedHandler)
 
+	// Determine the port
 	port := "8000"
 	if p := os.Getenv("PORT"); p != "" {
 		port = p
 	}
+
 	fmt.Printf("Server running on http://localhost:%s\n", port)
 	log.Fatal(http.ListenAndServe(":"+port, nil))
 }

--- a/reference-api/unified_handler.go
+++ b/reference-api/unified_handler.go
@@ -40,14 +40,20 @@ func (deps *HandlerDeps) UnifiedHandler(w http.ResponseWriter, r *http.Request) 
 
 	if repo == "" || gitRef == "" {
 		w.WriteHeader(http.StatusBadRequest)
-		_, _ = fmt.Fprintln(w, "Missing 'repo' or 'gitRef' query parameter")
+		_, err := fmt.Fprintln(w, "Missing 'repo' or 'gitRef' query parameter")
+		if err != nil {
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		}
 		return
 	}
 
 	if gitRef == "latest" {
-		w.WriteHeader(http.StatusBadRequest)
-		_, _ = fmt.Fprintln(w, "'latest' is not a valid value for 'gitRef' please use an immutable image")
-		return
+		errMsg := "'latest' is not a valid value for 'gitRef' please use an immutable image that matches a gitRef on" +
+			" your application repository"
+		_, err := fmt.Fprintln(w, errMsg)
+		if err != nil {
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		}
 	}
 
 	cacheKey := fmt.Sprintf("%s:%s", repo, gitRef)

--- a/reference-api/unified_handler.go
+++ b/reference-api/unified_handler.go
@@ -1,19 +1,30 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
+	"log"
 	"net/http"
 	"regexp"
+
+	lru "github.com/hashicorp/golang-lru/v2"
 )
 
 type HandlerDeps struct {
 	CommitsHandler  http.HandlerFunc
 	ReleasesHandler http.HandlerFunc
+	cache           *lru.Cache[string, []byte]
 }
 
 type responseRecorder struct {
 	http.ResponseWriter
 	statusCode int
+	body       bytes.Buffer
+}
+
+func (rec *responseRecorder) Write(p []byte) (int, error) {
+	rec.body.Write(p)
+	return rec.ResponseWriter.Write(p)
 }
 
 func (rec *responseRecorder) WriteHeader(code int) {
@@ -21,7 +32,7 @@ func (rec *responseRecorder) WriteHeader(code int) {
 	rec.ResponseWriter.WriteHeader(code)
 }
 
-// UnifiedHandler decides between using the CommitsHandler or ReleasesHandler based on gitRef format
+// UnifiedHandler with in-memory caching
 func (deps *HandlerDeps) UnifiedHandler(w http.ResponseWriter, r *http.Request) {
 	// Extract query parameters
 	repo := r.URL.Query().Get("repo")
@@ -29,39 +40,62 @@ func (deps *HandlerDeps) UnifiedHandler(w http.ResponseWriter, r *http.Request) 
 
 	if repo == "" || gitRef == "" {
 		w.WriteHeader(http.StatusBadRequest)
-		_, err := fmt.Fprintln(w, "Missing 'repo' or 'gitRef' query parameter")
-		if err != nil {
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-		}
+		_, _ = fmt.Fprintln(w, "Missing 'repo' or 'gitRef' query parameter")
 		return
 	}
 
-	// Return an error if gitRef is "latest"
 	if gitRef == "latest" {
 		w.WriteHeader(http.StatusBadRequest)
-		errMsg := "'latest' is not a valid value for 'gitRef' please use an immutable image that matches a gitRef on" +
-			" your application repository"
-		_, err := fmt.Fprintln(w, errMsg)
-		if err != nil {
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-		}
+		_, _ = fmt.Fprintln(w, "'latest' is not a valid value for 'gitRef' please use an immutable image")
 		return
 	}
 
-	// Determine if gitRef looks like a commit hash (short or full)
-	commitHashRegex := regexp.MustCompile(`^[a-fA-F0-9]{7,40}$`) // Match 7 to 40 hexadecimal characters
+	cacheKey := fmt.Sprintf("%s:%s", repo, gitRef)
+
+	// Check cache
+	if cachedResponse, ok := deps.getFromCache(cacheKey); ok {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(cachedResponse)
+		return
+	}
+
+	// Determine if gitRef looks like a commit hash
+	commitHashRegex := regexp.MustCompile(`^[a-fA-F0-9]{7,40}$`)
 	if commitHashRegex.MatchString(gitRef) {
-		// Handle as a commit
-		deps.CommitsHandler(w, r)
+		rec := &responseRecorder{ResponseWriter: w, statusCode: 200}
+		deps.CommitsHandler(rec, r)
+		deps.storeInCache(cacheKey, rec.body.Bytes()) // Cache response
 		return
 	}
 
-	// Attempt to handle as a release
+	// Try handling as a release first
 	releaseRecorder := &responseRecorder{ResponseWriter: w, statusCode: 200}
 	deps.ReleasesHandler(releaseRecorder, r)
 
-	// Fall back to commits if no release is found
-	if releaseRecorder.statusCode == http.StatusNotFound {
-		deps.CommitsHandler(w, r)
+	// If release is found, cache and return it
+	if releaseRecorder.statusCode != http.StatusNotFound {
+		deps.storeInCache(cacheKey, releaseRecorder.body.Bytes())
+		return
 	}
+
+	// Fall back to commits if no release is found
+	commitRecorder := &responseRecorder{ResponseWriter: w, statusCode: 200}
+	deps.CommitsHandler(commitRecorder, r)
+
+	// Cache the final commit response
+	deps.storeInCache(cacheKey, commitRecorder.body.Bytes())
+}
+
+func (deps *HandlerDeps) getFromCache(key string) ([]byte, bool) {
+	if value, ok := deps.cache.Get(key); ok {
+		log.Printf("Cache hit for key: %s", key)
+		return value, true
+	}
+	log.Printf("Cache miss for key: %s", key)
+	return nil, false
+}
+
+func (deps *HandlerDeps) storeInCache(key string, value []byte) {
+	deps.cache.Add(key, value)
+	log.Printf("Cached response for key: %s", key)
 }


### PR DESCRIPTION
**Description**
We have been hitting github rate limits in our sandbox environment. We are doing some session caching in the UI component, but we should be caching github responses in the backend as well. Using golang-lru to start. 

**CHANGES:** 
* Using golang-lru for caching 
* Added `CacheSize` environment variable to override default of 1000 items 
* Caching github responses to reduce likelihood of rate limiting unauthenticated (still suggest using a github app when possible) 