### PR TITLE
feat(reference-api): updated cache to store successful responses for 24 hours and non-200 respones for 1hr, saving res

### DIFF
--- a/reference-api/main.go
+++ b/reference-api/main.go
@@ -6,18 +6,17 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"time"
 
 	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/mozilla/argocd-repository-details/reference-api/sources/github"
 )
 
 func onEvict(key string, value CachedResponse) {
-	// Function called during eviction, log key evicted from cache
 	log.Printf("Evicted from cache: %s", key)
 }
 
 func main() {
-	// Create an LRU cache with eviction callback, cacheSize configurable by environment variable (CacheSize)
 	cacheSize := 1000
 	if cs := os.Getenv("CacheSize"); cs != "" {
 		if parsedSize, err := strconv.Atoi(cs); err == nil {
@@ -27,23 +26,50 @@ func main() {
 		}
 	}
 
-	// Create the LRU cache with the correct type
 	cache, err := lru.NewWithEvict[string, CachedResponse](cacheSize, onEvict)
 	if err != nil {
 		log.Fatalf("Failed to create cache: %v", err)
 	}
 
-	// Initialize dependencies with cache
+	// Default expiration durations
+	const (
+		defaultSuccessDuration = 24 * time.Hour
+		defaultErrorDuration   = 1 * time.Hour
+	)
+
+	cacheConfig := cacheConfiguration{
+		SuccessCacheDuration: defaultSuccessDuration,
+		ErrorCacheDuration:   defaultErrorDuration,
+	}
+
+	if scd := os.Getenv("CACHE_SUCCESS_DURATION"); scd != "" {
+		duration, err := strconv.Atoi(scd)
+		if err != nil || duration < 0 {
+			log.Printf("Warning: Invalid CACHE_SUCCESS_DURATION: %s. Using default: %v", scd, defaultSuccessDuration)
+		} else {
+			cacheConfig.SuccessCacheDuration = time.Duration(duration) * time.Hour
+		}
+	}
+
+	if ecd := os.Getenv("CACHE_ERROR_DURATION"); ecd != "" {
+		duration, err := strconv.Atoi(ecd)
+		if err != nil || duration < 0 {
+			log.Printf("Warning: Invalid CACHE_ERROR_DURATION: %s. Using default: %v", ecd, defaultErrorDuration)
+		} else {
+			cacheConfig.ErrorCacheDuration = time.Duration(duration) * time.Hour
+		}
+	}
+
 	deps := &HandlerDeps{
 		CommitsHandler:  github.CommitsHandler,
 		ReleasesHandler: github.ReleasesHandler,
 		cache:           cache,
+		config:          cacheConfig,
 	}
 
 	// Unified handler for both releases and commits, may support additional sources in the future.
 	http.HandleFunc("/api/references", deps.UnifiedHandler)
 
-	// Determine the port
 	port := "8000"
 	if p := os.Getenv("PORT"); p != "" {
 		port = p

--- a/reference-api/main.go
+++ b/reference-api/main.go
@@ -11,7 +11,7 @@ import (
 	"github.com/mozilla/argocd-repository-details/reference-api/sources/github"
 )
 
-func onEvict(key string, value []byte) {
+func onEvict(key string, value CachedResponse) {
 	// Function called during eviction, log key evicted from cache
 	log.Printf("Evicted from cache: %s", key)
 }
@@ -27,7 +27,8 @@ func main() {
 		}
 	}
 
-	cache, err := lru.NewWithEvict[string, []byte](cacheSize, onEvict)
+	// Create the LRU cache with the correct type
+	cache, err := lru.NewWithEvict[string, CachedResponse](cacheSize, onEvict)
 	if err != nil {
 		log.Fatalf("Failed to create cache: %v", err)
 	}

--- a/reference-api/main_test.go
+++ b/reference-api/main_test.go
@@ -177,7 +177,11 @@ func TestUnifiedHandlerWithCache(t *testing.T) {
 	t.Run("Cache Eviction (Size-Based)", func(t *testing.T) {
 		for i := 1; i <= 6; i++ { // Exceed cache limit of 5
 			cacheKey := fmt.Sprintf("repo%d:gitRef%d", i, i)
-			cache.Add(cacheKey, CachedResponse{StatusCode: http.StatusOK, Body: []byte(fmt.Sprintf(`{"handler": "test%d"}`, i)), Timestamp: time.Now().Unix()})
+			cache.Add(cacheKey, CachedResponse{
+				StatusCode: http.StatusOK,
+				Body:       []byte(fmt.Sprintf(`{"handler": "test%d"}`, i)),
+				Timestamp:  time.Now().Unix(),
+			})
 			time.Sleep(10 * time.Millisecond) // Allow eviction logging to appear
 		}
 

--- a/reference-api/main_test.go
+++ b/reference-api/main_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// Mock handlers
+// Mock handlers for testing
 func mockCommitsHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	fmt.Fprint(w, `{"handler": "commits"}`)
@@ -22,45 +22,58 @@ func mockReleasesHandler(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprint(w, `{"handler": "releases"}`)
 }
 
+// Mock release handler that simulates a 404 (to trigger commit fallback)
+func mockReleasesHandler404(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotFound)
+	fmt.Fprint(w, `Not Found`)
+}
+
 func TestUnifiedHandlerWithCache(t *testing.T) {
 	// Create an LRU cache with 5 items max (to test eviction easily)
-	cache, err := lru.NewWithEvict[string, []byte](5, onEvict)
+	cache, err := lru.NewWithEvict[string, CachedResponse](5, onEvict)
 	assert.NoError(t, err, "Failed to initialize cache")
 
-	// Mock dependencies with cache
-	deps := &HandlerDeps{
-		CommitsHandler:  mockCommitsHandler,
-		ReleasesHandler: mockReleasesHandler,
-		cache:           cache,
-	}
-
+	// Test cases
 	tests := []struct {
-		name           string
-		repo           string
-		gitRef         string
-		expectedStatus int
-		expectedBody   string
+		name             string
+		repo             string
+		gitRef           string
+		expectedStatus   int
+		expectedBody     string
+		use404Releases   bool // Whether to simulate a 404 response from ReleasesHandler
+		expectedCacheKey string
 	}{
 		{
-			name:           "Valid short commit SHA (should be cached)",
-			repo:           "test/repo",
-			gitRef:         "abc1234",
-			expectedStatus: http.StatusOK,
-			expectedBody:   `{"handler": "commits"}`,
-		},
-		{
-			name:           "Valid full commit SHA (should be cached)",
-			repo:           "test/repo",
-			gitRef:         "abcdef1234567890abcdef1234567890abcdef12",
-			expectedStatus: http.StatusOK,
-			expectedBody:   `{"handler": "commits"}`,
-		},
-		{
-			name:           "Valid tag (should be cached)",
+			name:           "Valid release tag (should be cached from releases)",
 			repo:           "test/repo",
 			gitRef:         "v1.0.0",
 			expectedStatus: http.StatusOK,
 			expectedBody:   `{"handler": "releases"}`,
+			use404Releases: false, // Should be served from ReleasesHandler
+		},
+		{
+			name:           "Valid short commit SHA (release 404s, should fall back to commits)",
+			repo:           "test/repo",
+			gitRef:         "abc1234",
+			expectedStatus: http.StatusOK,
+			expectedBody:   `{"handler": "commits"}`,
+			use404Releases: true, // Simulate a 404 from ReleasesHandler
+		},
+		{
+			name:           "Valid full commit SHA (release 404s, should fall back to commits)",
+			repo:           "test/repo",
+			gitRef:         "abcdef1234567890abcdef1234567890abcdef12",
+			expectedStatus: http.StatusOK,
+			expectedBody:   `{"handler": "commits"}`,
+			use404Releases: true, // Simulate a 404 from ReleasesHandler
+		},
+		{
+			name:           "Invalid gitRef format (should still be processed by ReleasesHandler)",
+			repo:           "test/repo",
+			gitRef:         "not-a-commit-or-tag",
+			expectedStatus: http.StatusOK,
+			expectedBody:   `{"handler": "releases"}`,
+			use404Releases: false, // Should be served from ReleasesHandler
 		},
 		{
 			name:           "Missing repo parameter",
@@ -76,18 +89,24 @@ func TestUnifiedHandlerWithCache(t *testing.T) {
 			expectedStatus: http.StatusBadRequest,
 			expectedBody:   "Missing 'repo' or 'gitRef' query parameter\n",
 		},
-		{
-			name:           "Invalid gitRef format (should be cached)",
-			repo:           "test/repo",
-			gitRef:         "not-a-commit-or-tag",
-			expectedStatus: http.StatusOK,
-			expectedBody:   `{"handler": "releases"}`,
-		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Logf("Running test: %s", tt.name) // Output test name
+			t.Logf("Running test: %s", tt.name)
+
+			// Mock dependencies based on whether we want a 404 for releases
+			releaseHandler := mockReleasesHandler
+			if tt.use404Releases {
+				releaseHandler = mockReleasesHandler404
+			}
+
+			// Initialize dependencies with the selected release handler
+			deps := &HandlerDeps{
+				CommitsHandler:  mockCommitsHandler,
+				ReleasesHandler: releaseHandler,
+				cache:           cache,
+			}
 
 			// Create a mock HTTP request
 			req := httptest.NewRequest("GET", "/api/references", nil)
@@ -114,23 +133,56 @@ func TestUnifiedHandlerWithCache(t *testing.T) {
 			cachedData, found := deps.getFromCache(cacheKey)
 			if tt.expectedStatus == http.StatusOK {
 				assert.True(t, found, "Expected response to be cached")
-				assert.Equal(t, tt.expectedBody, string(cachedData))
+				assert.Equal(t, tt.expectedStatus, cachedData.StatusCode, "Cached status code mismatch")
+				assert.Equal(t, tt.expectedBody, string(cachedData.Body), "Cached body mismatch")
+			} else {
+				assert.False(t, found, "Did not expect response to be cached for error status")
 			}
 		})
-
 	}
 
-	// Additional test: Cache eviction after exceeding max size
-	t.Run("Cache Eviction", func(t *testing.T) {
-		// Add more entries to force eviction
+	// Cache expiration test
+	t.Run("Cache Expiration", func(t *testing.T) {
+		// Initialize cache with a test-specific instance
+		cache, err := lru.NewWithEvict[string, CachedResponse](5, onEvict)
+		assert.NoError(t, err, "Failed to initialize cache")
+
+		// Initialize a fresh HandlerDeps struct for this test
+		deps := &HandlerDeps{
+			CommitsHandler:  mockCommitsHandler,
+			ReleasesHandler: mockReleasesHandler,
+			cache:           cache,
+		}
+
+		cacheKey := "test/repo:expired-entry"
+		currentTime := time.Now().Unix()
+
+		// Store a 200 response (should expire in 24 hours)
+		deps.storeInCache(cacheKey, http.StatusOK, []byte(`{"handler": "commits"}`))
+
+		// Ensure the response is stored
+		cachedResponse, found := deps.cache.Get(cacheKey)
+		assert.True(t, found, "Expected cached item to be present before expiration")
+
+		// Manually modify the timestamp to simulate expiration (set to 25 hours ago)
+		cachedResponse.Timestamp = currentTime - int64(25*time.Hour.Seconds())
+		deps.cache.Add(cacheKey, cachedResponse) // Re-insert the modified entry
+
+		// Ensure cache entry is now expired
+		_, found = deps.getFromCache(cacheKey)
+		assert.False(t, found, "Expected cached item to be evicted after 24 hours")
+	})
+
+	// Cache size-based eviction test (unchanged)
+	t.Run("Cache Eviction (Size-Based)", func(t *testing.T) {
 		for i := 1; i <= 6; i++ { // Exceed cache limit of 5
 			cacheKey := fmt.Sprintf("repo%d:gitRef%d", i, i)
-			deps.storeInCache(cacheKey, []byte(fmt.Sprintf(`{"handler": "test%d"}`, i)))
+			cache.Add(cacheKey, CachedResponse{StatusCode: http.StatusOK, Body: []byte(fmt.Sprintf(`{"handler": "test%d"}`, i)), Timestamp: time.Now().Unix()})
 			time.Sleep(10 * time.Millisecond) // Allow eviction logging to appear
 		}
 
 		// Check if the first entry was evicted
-		_, found := deps.getFromCache("repo1:gitRef1")
+		_, found := cache.Get("repo1:gitRef1")
 		assert.False(t, found, "Expected first cached item to be evicted")
 	})
 }

--- a/reference-api/sources/github/commits.go
+++ b/reference-api/sources/github/commits.go
@@ -47,7 +47,6 @@ func FetchLatestCommit(repo string) (*github.RepositoryCommit, error) {
 
 // FetchCommits fetches both the latest commit and the one matching the Git reference (gitRef)
 func FetchCommits(repo, gitRef string) (*StandardizedOutput, int, error) {
-	// Fetch the current commit
 	currentCommit, err := FetchCommit(repo, gitRef)
 	if err != nil {
 		log.Printf("Error fetching current commit: %v", err)
@@ -57,7 +56,6 @@ func FetchCommits(repo, gitRef string) (*StandardizedOutput, int, error) {
 		return nil, http.StatusInternalServerError, fmt.Errorf("error fetching commit: %v", err)
 	}
 
-	// Fetch the latest commit
 	latestCommit, err := FetchLatestCommit(repo)
 	if err != nil {
 		log.Printf("Error fetching latest commit: %v", err)
@@ -90,14 +88,12 @@ func CommitsHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Fetch the commits and get the response status
 	commits, statusCode, err := FetchCommits(repo, gitRef)
 	if err != nil {
-		errorEncoder(w, statusCode, err.Error()) // Return correct status code
+		errorEncoder(w, statusCode, err.Error())
 		return
 	}
 
-	// Set response headers and send response
 	w.Header().Set("Content-Type", "application/json")
 	responseEncoder(w, statusCode, commits)
 }

--- a/reference-api/sources/github/releases.go
+++ b/reference-api/sources/github/releases.go
@@ -10,7 +10,6 @@ import (
 	"github.com/google/go-github/v67/github"
 )
 
-// Release represents a GitHub release
 type Release struct {
 	TagName     string `json:"tag_name"`
 	URL         string `json:"html_url"`
@@ -30,10 +29,8 @@ func FetchReleases(repo, gitRef string) (*StandardizedOutput, error) {
 	client := NewGithubClient(repo)
 	ctx := context.Background()
 
-	// Perform GitHub API request
 	releases, resp, err := client.Repositories.ListReleases(ctx, owner, repoName, nil)
 
-	// Handle HTTP response errors
 	if err != nil {
 		if resp != nil && resp.StatusCode == http.StatusNotFound {
 			return nil, fmt.Errorf("404 Not Found: No releases found for repo %s", repo)
@@ -63,7 +60,6 @@ func FetchReleases(repo, gitRef string) (*StandardizedOutput, error) {
 		}
 	}
 
-	// Return the standardized response
 	return &StandardizedOutput{
 		Latest:  StandardizeRelease(latestRelease),
 		Current: StandardizeRelease(matchingRelease),
@@ -99,12 +95,10 @@ func ReleasesHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Check if a release was found
 	if releases == nil || (releases.Current == nil) {
 		errorEncoder(w, http.StatusNotFound, "No release found for the given repository and gitRef")
 		return
 	}
 
-	// Return release details
 	responseEncoder(w, http.StatusOK, releases)
 }

--- a/reference-api/sources/github/releases.go
+++ b/reference-api/sources/github/releases.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"net/http"
 	"strings"
@@ -28,9 +29,16 @@ func FetchReleases(repo, gitRef string) (*StandardizedOutput, error) {
 	owner, repoName, _ := strings.Cut(repo, "/")
 	client := NewGithubClient(repo)
 	ctx := context.Background()
-	releases, _, err := client.Repositories.ListReleases(ctx, owner, repoName, nil)
+
+	// Perform GitHub API request
+	releases, resp, err := client.Repositories.ListReleases(ctx, owner, repoName, nil)
+
+	// Handle HTTP response errors
 	if err != nil {
-		return nil, err
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			return nil, fmt.Errorf("404 Not Found: No releases found for repo %s", repo)
+		}
+		return nil, fmt.Errorf("GitHub API error: %v", err)
 	}
 
 	var latestRelease *github.RepositoryRelease
@@ -55,7 +63,7 @@ func FetchReleases(repo, gitRef string) (*StandardizedOutput, error) {
 		}
 	}
 
-	// Normalize the releases
+	// Return the standardized response
 	return &StandardizedOutput{
 		Latest:  StandardizeRelease(latestRelease),
 		Current: StandardizeRelease(matchingRelease),
@@ -81,15 +89,22 @@ func ReleasesHandler(w http.ResponseWriter, r *http.Request) {
 	releases, err := FetchReleases(repo, gitRef)
 	if err != nil {
 		log.Printf("Error fetching releases: %v", err)
-		errorEncoder(w, http.StatusInternalServerError, "Failed to fetch release information")
+
+		// If the error is due to GitHub returning a non-200 response, set the correct status
+		if strings.Contains(err.Error(), "404") {
+			errorEncoder(w, http.StatusNotFound, "GitHub API returned 404: Release not found")
+		} else {
+			errorEncoder(w, http.StatusInternalServerError, "Failed to fetch release information")
+		}
+		return
 	}
 
 	// Check if a release was found
-	if releases == nil || (releases.Current == nil || releases.Latest == nil) {
+	if releases == nil || (releases.Current == nil) {
 		errorEncoder(w, http.StatusNotFound, "No release found for the given repository and gitRef")
+		return
 	}
 
 	// Return release details
 	responseEncoder(w, http.StatusOK, releases)
-
 }


### PR DESCRIPTION
**CHANGES:**
* add time expiry on cached data
* save response code in cache and ensure the correct code is being passed from the github API response
* added new test cases
* look for a github release first and fall back to a commit if no release is found 

**FIXES:** 
* Resolved issue with failed github API responses being cached and returning a 200 response when read from cache 